### PR TITLE
removes role=document

### DIFF
--- a/src/html/templates/main.njk
+++ b/src/html/templates/main.njk
@@ -58,7 +58,7 @@
     <!-- SVGs for use -->
     <div id="layout-svgs" class="layout-svgs"></div>
 
-    <div id="site-container" class="site-container" role="document">
+	<div id="site-container" class="site-container">
 
         <!-- Header -->
         <header id="header" class="header" role="banner">


### PR DESCRIPTION
there is no reason to add a `role=document` to this element.  As there is no wrapping `role=application` (nor should there be) the page will already be treated as a document.

[`role=document`](https://www.w3.org/TR/wai-aria-1.1/#document) as defined by the ARIA 1.1 specification, for more information on appropriate usage.